### PR TITLE
Allow developers to customize Android notifications text

### DIFF
--- a/samples/ScreenRecordingSample/MainPage.xaml
+++ b/samples/ScreenRecordingSample/MainPage.xaml
@@ -30,8 +30,8 @@
 			</VerticalStackLayout>
 
 			<VerticalStackLayout>
-				<Entry x:Name="ContentTitle" Text="Screen Recording" Placeholder="Enter the nofitication content title" IsVisible="false"/>
-				<Entry x:Name="ContentText" Text="Recording screen..." Placeholder="Enter the nofitication content text" IsVisible="false"/>
+				<Entry x:Name="ContentTitle" Text="Screen Recording" Placeholder="Enter the notification content title" IsVisible="false"/>
+				<Entry x:Name="ContentText" Text="Recording screen..." Placeholder="Enter the notification content text" IsVisible="false"/>
 			</VerticalStackLayout>
 
 				<Button Text="Start Recording" Clicked="StartRecordingClicked" x:Name="btnStart" />

--- a/samples/ScreenRecordingSample/MainPage.xaml
+++ b/samples/ScreenRecordingSample/MainPage.xaml
@@ -23,9 +23,18 @@
                     <Switch x:Name="saveToGallery" VerticalOptions="Center" />
                     <Label Text="Save to gallery (iOS/macOS only)" VerticalOptions="Center" />
                 </HorizontalStackLayout>
-            </VerticalStackLayout>
+				<HorizontalStackLayout Spacing="5">
+					<Switch x:Name="setCustomNotification" VerticalOptions="Center" Toggled="OnToggled"/>
+					<Label Text="Set custom text for notification (Android only)" VerticalOptions="Center" />
+				</HorizontalStackLayout>
+			</VerticalStackLayout>
 
-                <Button Text="Start Recording" Clicked="StartRecordingClicked" x:Name="btnStart" />
+			<VerticalStackLayout>
+				<Entry x:Name="ContentTitle" Text="Screen Recording" Placeholder="Enter the nofitication content title" IsVisible="false"/>
+				<Entry x:Name="ContentText" Text="Recording screen..." Placeholder="Enter the nofitication content text" IsVisible="false"/>
+			</VerticalStackLayout>
+
+				<Button Text="Start Recording" Clicked="StartRecordingClicked" x:Name="btnStart" />
                 <Button Text="Stop Recording" Clicked="StopRecordingClicked" x:Name="btnStop" />
         </VerticalStackLayout>
     </ScrollView>

--- a/samples/ScreenRecordingSample/MainPage.xaml.cs
+++ b/samples/ScreenRecordingSample/MainPage.xaml.cs
@@ -25,11 +25,24 @@ public partial class MainPage : ContentPage
 
 		btnStart.IsEnabled = false;
 		btnStop.IsEnabled = true;
-		screenRecording.StartRecording(new() 
-		{ 
-			EnableMicrophone = recordMicrophone.IsToggled,
-			SaveToGallery = saveToGallery.IsToggled,
-		});
+		if (setCustomNotification.IsToggled)
+		{
+			screenRecording.StartRecording(new()
+			{
+				EnableMicrophone = recordMicrophone.IsToggled,
+				SaveToGallery = saveToGallery.IsToggled,
+				SetNotificationContentTitle = ContentTitle.Text,
+				SetNotificationContentText = ContentText.Text
+			});
+		}
+		else
+		{
+			screenRecording.StartRecording(new()
+			{
+				EnableMicrophone = recordMicrophone.IsToggled,
+				SaveToGallery = saveToGallery.IsToggled
+			});
+		}
 	}
 
 	async void StopRecordingClicked(object sender, EventArgs e)
@@ -50,5 +63,11 @@ public partial class MainPage : ContentPage
 
 		btnStart.IsEnabled = true;
 		btnStop.IsEnabled = false;
+	}
+
+	void OnToggled(object sender, ToggledEventArgs e)
+	{
+		ContentTitle.IsVisible = e.Value;
+		ContentText.IsVisible = e.Value;
 	}
 }

--- a/samples/ScreenRecordingSample/MainPage.xaml.cs
+++ b/samples/ScreenRecordingSample/MainPage.xaml.cs
@@ -31,8 +31,8 @@ public partial class MainPage : ContentPage
 			{
 				EnableMicrophone = recordMicrophone.IsToggled,
 				SaveToGallery = saveToGallery.IsToggled,
-				SetNotificationContentTitle = ContentTitle.Text,
-				SetNotificationContentText = ContentText.Text
+				NotificationContentTitle = ContentTitle.Text,
+				NotificationContentText = ContentText.Text
 			});
 		}
 		else

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
@@ -13,8 +13,8 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 	string? filePath;
 	bool enableMicrophone;
 
-	string SetNotificationContentTitle { get; set; }
-	string SetSetNotificationContentText { get; set; }
+	string NotificationContentTitle { get; set; }
+	string NotificationContentText { get; set; }
 
 	MediaProjectionManager? ProjectionManager { get; set; }
 	MediaProjection? MediaProjection { get; set; }
@@ -36,8 +36,8 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 		{
 			enableMicrophone = options?.EnableMicrophone ?? false;
 
-			SetNotificationContentTitle = options?.SetNotificationContentTitle ?? "Screen Recording";
-			SetSetNotificationContentText = options?.SetNotificationContentText ?? "Recording screen...";
+			NotificationContentTitle = options?.NotificationContentTitle ?? "Screen Recording";
+			NotificationContentText = options?.NotificationContentText ?? "Recording screen...";
 
 			var saveOptions = options ?? new();
 			var savePath = saveOptions.SavePath;
@@ -102,8 +102,8 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 	internal async void OnScreenCapturePermissionGranted(int resultCode, Intent? data)
 	{
 		Intent intent = new(Application.Context, typeof(ScreenRecordingService));
-		intent.PutExtra("ContentTitle", SetNotificationContentTitle);
-		intent.PutExtra("ContentText", SetSetNotificationContentText);
+		intent.PutExtra("ContentTitle", NotificationContentTitle);
+		intent.PutExtra("ContentText", NotificationContentText);
 
 		// Android O
 		if (OperatingSystem.IsAndroidVersionAtLeast(26))

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
@@ -13,6 +13,9 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 	string? filePath;
 	bool enableMicrophone;
 
+	string SetNotificationContentTitle { get; set; }
+	string SetSetNotificationContentText { get; set; }
+
 	MediaProjectionManager? ProjectionManager { get; set; }
 	MediaProjection? MediaProjection { get; set; }
 	VirtualDisplay? VirtualDisplay { get; set; }
@@ -32,6 +35,9 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 		if (IsSupported)
 		{
 			enableMicrophone = options?.EnableMicrophone ?? false;
+
+			SetNotificationContentTitle = options?.SetNotificationContentTitle ?? "Screen Recording";
+			SetSetNotificationContentText = options?.SetNotificationContentText ?? "Recording screen...";
 
 			var saveOptions = options ?? new();
 			var savePath = saveOptions.SavePath;
@@ -96,6 +102,8 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 	internal async void OnScreenCapturePermissionGranted(int resultCode, Intent? data)
 	{
 		Intent intent = new(Application.Context, typeof(ScreenRecordingService));
+		intent.PutExtra("ContentTitle", SetNotificationContentTitle);
+		intent.PutExtra("ContentText", SetSetNotificationContentText);
 
 		// Android O
 		if (OperatingSystem.IsAndroidVersionAtLeast(26))

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
@@ -13,8 +13,11 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 	string? filePath;
 	bool enableMicrophone;
 
-	string NotificationContentTitle { get; set; }
-	string NotificationContentText { get; set; }
+	string NotificationContentTitle { get; set; } =
+		ScreenRecordingOptions.defaultAndroidNotificationTitle;
+
+	string NotificationContentText { get; set; } =
+		ScreenRecordingOptions.defaultAndroidNotificationText;
 
 	MediaProjectionManager? ProjectionManager { get; set; }
 	MediaProjection? MediaProjection { get; set; }
@@ -32,30 +35,35 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 
 	public void StartRecording(ScreenRecordingOptions? options = null)
 	{
-		if (IsSupported)
-		{
-			enableMicrophone = options?.EnableMicrophone ?? false;
-
-			NotificationContentTitle = options?.NotificationContentTitle ?? "Screen Recording";
-			NotificationContentText = options?.NotificationContentText ?? "Recording screen...";
-
-			var saveOptions = options ?? new();
-			var savePath = saveOptions.SavePath;
-
-			if (string.IsNullOrWhiteSpace(savePath))
-			{
-				savePath = Path.Combine(Path.GetTempPath(),
-					$"screenrecording_{DateTime.Now:ddMMyyyy_HHmmss}.mp4");
-			}
-
-			filePath = savePath;
-
-			Setup();
-		}
-		else
+		if (!IsSupported)
 		{
 			throw new NotSupportedException("Screen recording not supported on this device.");
 		}
+		
+		enableMicrophone = options?.EnableMicrophone ?? false;
+
+		if (!string.IsNullOrWhiteSpace(options?.NotificationContentTitle))
+		{
+			NotificationContentTitle = options.NotificationContentTitle;
+		}
+
+		if (!string.IsNullOrWhiteSpace(options?.NotificationContentText))
+		{
+			NotificationContentText = options.NotificationContentText;
+		}
+
+		var saveOptions = options ?? new();
+		var savePath = saveOptions.SavePath;
+
+		if (string.IsNullOrWhiteSpace(savePath))
+		{
+			savePath = Path.Combine(Path.GetTempPath(),
+				$"screenrecording_{DateTime.Now:ddMMyyyy_HHmmss}.mp4");
+		}
+
+		filePath = savePath;
+
+		Setup();
 	}
 
 	public Task<ScreenRecordingFile?> StopRecording()

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecordingOptions.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecordingOptions.cs
@@ -2,6 +2,9 @@
 
 public class ScreenRecordingOptions
 {
+	internal const string defaultAndroidNotificationTitle = "Screen recording in progress...";
+	internal const string defaultAndroidNotificationText = "A screen recording is currently in progress, be careful with any sensitive information.";
+	
 	/// <summary>
 	/// Gets or sets the path to save the recording to.
 	/// The default is the device's temporary folder with a timestamped file,
@@ -24,15 +27,15 @@ public class ScreenRecordingOptions
 
 	/// <summary>
 	/// Gets or sets the notification content title.
-	/// Default value is "Screen Recording".
+	/// Default value is "Screen recording in progress...".
 	/// </summary>
 	/// <remarks>This property only has effect on Android. On other platforms no notification is shown when a screen recording is being made.</remarks>
-	public string NotificationContentTitle { get; set; }
+	public string NotificationContentTitle { get; set; } = defaultAndroidNotificationTitle;
 
 	/// <summary>
 	/// Gets or sets the notification content text.
-	/// Default value is "Recording screen...".
+	/// Default value is "A screen recording is currently in progress, be careful with any sensitive information.".
 	/// </summary>
 	/// <remarks>This property only has effect on Android. On other platforms no notification is shown when a screen recording is being made.</remarks>
-	public string NotificationContentText { get; set; }
+	public string NotificationContentText { get; set; } = defaultAndroidNotificationText;
 }

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecordingOptions.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecordingOptions.cs
@@ -21,4 +21,18 @@ public class ScreenRecordingOptions
 	/// Default value is <see langword="false"/>.
 	/// </summary>
 	public bool EnableMicrophone { get; set; }
+
+	/// <summary>
+	/// Gets or sets the notification content title.
+	/// Default value is "Screen Recording".
+	/// </summary>
+	/// <remarks>Currently only implemented for Android.</remarks>
+	public string SetNotificationContentTitle { get; set; }
+
+	/// <summary>
+	/// Gets or sets the notification content text.
+	/// Default value is "Recording screen...".
+	/// </summary>
+	/// <remarks>Currently only implemented for Android.</remarks>
+	public string SetNotificationContentText { get; set; }
 }

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecordingOptions.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecordingOptions.cs
@@ -26,13 +26,13 @@ public class ScreenRecordingOptions
 	/// Gets or sets the notification content title.
 	/// Default value is "Screen Recording".
 	/// </summary>
-	/// <remarks>Currently only implemented for Android.</remarks>
-	public string SetNotificationContentTitle { get; set; }
+	/// <remarks>This property only has effect on Android. On other platforms no notification is shown when a screen recording is being made.</remarks>
+	public string NotificationContentTitle { get; set; }
 
 	/// <summary>
 	/// Gets or sets the notification content text.
 	/// Default value is "Recording screen...".
 	/// </summary>
-	/// <remarks>Currently only implemented for Android.</remarks>
-	public string SetNotificationContentText { get; set; }
+	/// <remarks>This property only has effect on Android. On other platforms no notification is shown when a screen recording is being made.</remarks>
+	public string NotificationContentText { get; set; }
 }

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecordingService.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecordingService.android.cs
@@ -32,11 +32,14 @@ class ScreenRecordingService : Service
 
 			notificationManager.CreateNotificationChannel(channel);
 
+			string contentTitle = intent.GetStringExtra("ContentTitle");
+			string contentText = intent.GetStringExtra("ContentText");
+
 			// TODO we probably want to find a way for people to set these values themselves for localization for instance
 			// Create a notification for the foreground service
 			var notificationBuilder = new Notification.Builder(this, CHANNEL_ID)
-				.SetContentTitle("Screen Recording")
-				.SetContentText("Recording screen...")
+				.SetContentTitle(contentTitle)
+				.SetContentText(contentText)
 				.SetSmallIcon(Resource.Drawable.notification_template_icon_low_bg); // Ensure you have 'ic_notification' in Resources/drawable
 
 			foregroundNotification = notificationBuilder.Build();

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecordingService.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecordingService.android.cs
@@ -32,8 +32,11 @@ class ScreenRecordingService : Service
 
 			notificationManager.CreateNotificationChannel(channel);
 
-			string contentTitle = intent.GetStringExtra("ContentTitle");
-			string contentText = intent.GetStringExtra("ContentText");
+			string contentTitle = intent?.GetStringExtra("ContentTitle") ??
+				ScreenRecordingOptions.defaultAndroidNotificationTitle;
+
+			string contentText = intent?.GetStringExtra("ContentText") ??
+				ScreenRecordingOptions.defaultAndroidNotificationText;
 
 			// Create a notification for the foreground service
 			var notificationBuilder = new Notification.Builder(this, CHANNEL_ID)

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecordingService.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecordingService.android.cs
@@ -35,7 +35,6 @@ class ScreenRecordingService : Service
 			string contentTitle = intent.GetStringExtra("ContentTitle");
 			string contentText = intent.GetStringExtra("ContentText");
 
-			// TODO we probably want to find a way for people to set these values themselves for localization for instance
 			// Create a notification for the foreground service
 			var notificationBuilder = new Notification.Builder(this, CHANNEL_ID)
 				.SetContentTitle(contentTitle)


### PR DESCRIPTION
## What's New?
- Where added two properties to the ScreenRecordingOptions called SetNotificationContentTitle and SetNotificationContentText
- Now users can set those properties to customize the notification text for android.

## Related Issue
Fixes #8 

## Visuals 

https://github.com/jfversluis/Plugin.Maui.ScreenRecording/assets/23615129/a4da1b10-6b94-4639-aa2e-8b2ddc308dc4

