### PR TITLE
MediaRecorder set null when stop - close issue #14

### DIFF
--- a/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
@@ -89,6 +89,7 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 			{
 				MediaRecorder?.Stop();
 				MediaRecorder?.Release();
+				MediaRecorder = null;
 				VirtualDisplay?.Release();
 			}
 			catch (Exception ex)


### PR DESCRIPTION
## What's new?
- MediaRecorder to null when stopping the recording process to avoid the application crash

## Related Issue
- Closes #14 

## Visuals (video for app crashing in the issue #14)

https://github.com/jfversluis/Plugin.Maui.ScreenRecording/assets/23615129/a7bd232b-27cc-4f2b-a25e-ac031408597f

