### PR TITLE
Refactor error handling across all platforms

### DIFF
--- a/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecording.android.cs
@@ -44,7 +44,7 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 	{
 		if (!IsSupported)
 		{
-			throw new NotSupportedException("Screen recording not supported on this device.");
+			throw new NotSupportedException("Screen recording is not supported on this device.");
 		}
 		
 		enableMicrophone = options?.EnableMicrophone ?? false;
@@ -101,19 +101,13 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 				MediaRecorder = null;
 				VirtualDisplay?.Release();
 			}
-			catch (Exception ex)
+			catch (Java.Lang.IllegalStateException ex)
 			{
-				Console.WriteLine("STACK TRACE:");
-				Console.WriteLine(ex.StackTrace);
-
-				Console.WriteLine("Exception Message:");
-				Console.WriteLine(ex.Message);
-
-				if (ex.InnerException != null)
-				{
-					Console.WriteLine("INNER Exception Message:");
-					Console.WriteLine(ex.InnerException.Message);
-				}
+				System.Diagnostics.Debug.WriteLine($"[ScreenRecording] MediaRecorder was in an invalid state: {ex.Message}");
+			}
+			catch (Java.Lang.RuntimeException ex)
+			{
+				System.Diagnostics.Debug.WriteLine($"[ScreenRecording] Failed to stop recording cleanly: {ex.Message}");
 			}
 			finally
 			{
@@ -191,10 +185,13 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
             MediaRecorder.Start();
             IsRecording = true;
         }
-        catch (Exception ex)
+        catch (Java.Lang.IllegalStateException ex)
         {
-            Console.WriteLine(ex);
-            throw new NotSupportedException("Screen recording did not start.");
+            throw new ScreenRecordingException("Failed to start recording. The MediaRecorder is in an invalid state.", ex);
+        }
+        catch (Java.IO.IOException ex)
+        {
+            throw new ScreenRecordingException("Failed to start recording due to an I/O error. Check that the save path is valid and writable.", ex);
         }
     }
 
@@ -262,11 +259,9 @@ public partial class ScreenRecordingImplementation : MediaProjection.Callback, I
 		}
 		catch (Java.IO.IOException ex)
 		{
-			Console.WriteLine($"MediaRecorder preparation failed: {ex.Message}");
-            // Handle preparation failure
-            VirtualDisplay?.Release();
-            MediaRecorder?.Release();
-			throw;
+			VirtualDisplay?.Release();
+			MediaRecorder?.Release();
+			throw new ScreenRecordingException($"MediaRecorder preparation failed: {ex.Message}", ex);
 		}
 
 		return MediaRecorder;

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecording.macios.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecording.macios.cs
@@ -35,7 +35,11 @@ public partial class ScreenRecordingImplementation : IScreenRecording
 
         RPScreenRecorder.SharedRecorder.StartRecording(error =>
 		{
-			// TODO do something with error?
+			if (error is not null)
+			{
+				System.Diagnostics.Debug.WriteLine($"[ScreenRecording] Failed to start recording: {error.LocalizedDescription}");
+			}
+
 			tcs.TrySetResult(error == null);
 		});
 
@@ -57,8 +61,8 @@ public partial class ScreenRecordingImplementation : IScreenRecording
 
 				if (permissionResult != PermissionStatus.Granted)
 				{
-					// TODO what do we do here?
-					return null;
+					throw new ScreenRecordingException(
+						"Photo library permission was not granted. The recording was saved to the temporary path but could not be added to the gallery.");
 				}
 
 				PHPhotoLibrary.SharedPhotoLibrary.PerformChanges(() =>
@@ -66,16 +70,14 @@ public partial class ScreenRecordingImplementation : IScreenRecording
 					PHAssetChangeRequest.FromVideo(savePath);
 				}, (success, error) =>
 				{
-					// TODO what to do here?
+					if (!success && error is not null)
+					{
+						System.Diagnostics.Debug.WriteLine($"[ScreenRecording] Failed to save to photo library: {error.LocalizedDescription}");
+					}
 				});
 			}
 
 			return new ScreenRecordingFile(savePath.Path ?? string.Empty);
-			// TODO show preview view controller?
-			// Show preview after recording, only on iOS/macOS
-			//var cv = await RPScreenRecorder.SharedRecorder.StopRecordingAsync();
-
-			//Platform.GetCurrentUIViewController().ShowViewController(cv, cv);
 		}
 
 		return null;

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecording.windows.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecording.windows.cs
@@ -1,65 +1,96 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using ScreenRecorderLib;
 using Windows.Graphics.Capture;
+
 namespace Plugin.Maui.ScreenRecording;
 
 public partial class ScreenRecordingImplementation : IScreenRecording
 {
     public ScreenRecordingImplementation()
     {
-
     }
+
     public bool IsRecording => _IsRecording;
-    private bool _IsRecording { get; set; } = false;
+    private bool _IsRecording { get; set; }
     public bool IsSupported => GraphicsCaptureSession.IsSupported();
     private Recorder? rec;
+    private string? filePath;
 
-    public async Task<bool> StartRecording(ScreenRecordingOptions? options)
+    public Task<bool> StartRecording(ScreenRecordingOptions? options)
     {
         if (!IsSupported)
-            throw new Exception("Screen recording not supported on this device.");
+        {
+            throw new NotSupportedException("Screen recording is not supported on this device.");
+        }
+
         var enableMicrophone = options?.EnableMicrophone ?? false;
 
         var saveOptions = options ?? new();
         var savePath = saveOptions.SavePath;
         var filename = $"screenrecording_{DateTime.Now:ddMMyyyy_HHmmss}.mp4";
+
         if (string.IsNullOrWhiteSpace(savePath))
         {
             savePath = Path.Combine(Path.GetTempPath(), filename);
         }
+
         if (saveOptions.SaveToGallery)
         {
             string myVideosPath = Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
             savePath = Path.Combine(myVideosPath, filename);
         }
+
         var source = DisplayRecordingSource.MainMonitor;
         source.RecorderApi = RecorderApi.WindowsGraphicsCapture;
-        
+
         var opts = new RecorderOptions
         {
             SourceOptions = new SourceOptions
             {
                 RecordingSources = { { source } },
             },
-            AudioOptions = new AudioOptions { IsInputDeviceEnabled = enableMicrophone, IsOutputDeviceEnabled = true, IsAudioEnabled = true }
-
+            AudioOptions = new AudioOptions
+            {
+                IsInputDeviceEnabled = enableMicrophone,
+                IsOutputDeviceEnabled = true,
+                IsAudioEnabled = true
+            }
         };
+
         rec = Recorder.CreateRecorder(opts);
-        rec.OnRecordingComplete += (s, e) =>
+        rec.OnRecordingFailed += (s, e) =>
         {
-            path = e.FilePath;
-            Debug.WriteLine("Recording completed");
+            Debug.WriteLine($"[ScreenRecording] Recording failed: {e.Error}");
             _IsRecording = false;
         };
-        rec.Record(path = savePath);
-        return true;
+        rec.OnRecordingComplete += (s, e) =>
+        {
+            filePath = e.FilePath;
+            Debug.WriteLine("[ScreenRecording] Recording completed");
+            _IsRecording = false;
+        };
+
+        filePath = savePath;
+        rec.Record(savePath);
+        _IsRecording = true;
+
+        return Task.FromResult(true);
     }
-    private string path { get; set; }
-    public async Task<ScreenRecordingFile?> StopRecording()
+
+    public Task<ScreenRecordingFile?> StopRecording()
     {
+        if (!IsRecording && rec is null)
+        {
+            return Task.FromResult<ScreenRecordingFile?>(null);
+        }
+
         rec?.Stop();
         rec?.Dispose();
         rec = null;
-        return new(path);
+        _IsRecording = false;
+
+        return Task.FromResult(string.IsNullOrEmpty(filePath)
+            ? null
+            : new ScreenRecordingFile(filePath));
     }
 }

--- a/src/Plugin.Maui.ScreenRecording/ScreenRecordingException.shared.cs
+++ b/src/Plugin.Maui.ScreenRecording/ScreenRecordingException.shared.cs
@@ -1,0 +1,32 @@
+namespace Plugin.Maui.ScreenRecording;
+
+/// <summary>
+/// Exception thrown when a screen recording operation fails.
+/// </summary>
+public class ScreenRecordingException : Exception
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ScreenRecordingException"/> class.
+	/// </summary>
+	public ScreenRecordingException()
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ScreenRecordingException"/> class with a specified error message.
+	/// </summary>
+	/// <param name="message">The error message that explains the reason for the exception.</param>
+	public ScreenRecordingException(string message) : base(message)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ScreenRecordingException"/> class with a specified error message
+	/// and a reference to the inner exception that is the cause of this exception.
+	/// </summary>
+	/// <param name="message">The error message that explains the reason for the exception.</param>
+	/// <param name="innerException">The exception that is the cause of the current exception.</param>
+	public ScreenRecordingException(string message, Exception innerException) : base(message, innerException)
+	{
+	}
+}


### PR DESCRIPTION
## Description

Fixes #4

Refactors error handling across Android, iOS/macOS, and Windows implementations.

### Changes

- **New**: `ScreenRecordingException` custom exception type for recording-specific errors
- **Android**: Replace `Console.WriteLine` with `System.Diagnostics.Debug.WriteLine` and catch specific exception types (`IllegalStateException`, `RuntimeException`) instead of bare `Exception`
- **Android**: `BeginRecording` now throws `ScreenRecordingException` with inner exception context instead of generic `NotSupportedException`
- **iOS/macOS**: Log ReplayKit errors via `Debug.WriteLine` instead of silently ignoring them
- **iOS/macOS**: Throw `ScreenRecordingException` when photo library permission is denied (previously returned null with no indication of why)
- **iOS/macOS**: Log photo library save failures with error details
- **Windows**: Replace generic `Exception` with `NotSupportedException` for consistency
- **Windows**: Add `OnRecordingFailed` handler, fix null-safety in `StopRecording`
- **Windows**: Remove unused `async` modifiers and clean up formatting

### Breaking Changes

- `StopRecording()` on iOS/macOS now throws `ScreenRecordingException` when photo library permission is denied (previously silently returned `null`)
- Android `BeginRecording` now throws `ScreenRecordingException` instead of `NotSupportedException`
